### PR TITLE
Update httpd.reb

### DIFF
--- a/httpd.reb
+++ b/httpd.reb
@@ -78,7 +78,7 @@ sys/make-scheme [
                         dispatch client
                     ]
 
-                    default [read client]
+                    default [if not empty? client/data [read client]]
                 ]
             ]
 

--- a/httpd.reb
+++ b/httpd.reb
@@ -456,6 +456,7 @@ sys/make-scheme [
                     keep [cr lf "Connection:" "close"]
                 ]
                 keep [cr lf "Cache-Control:" "no-cache"]
+                keep [cr lf "Access-Control-Allow-Origin: *"]
                 keep [cr lf cr lf]
             ]
         ])


### PR DESCRIPTION
If there is a `read` event, there must be data in the client/data.  So, this checks for this, and seems to halt the crashes from a web browser read.