### PR TITLE
Update httpd.reb

### DIFF
--- a/httpd.reb
+++ b/httpd.reb
@@ -391,10 +391,11 @@ sys/make-scheme [
             headers: make header-prototype
                 http-headers: new-line/skip headers true 2
 
-            type: try all [
+            type: all [
                 text? type: headers/Content-Type
-                copy/part type (opt find type ";")
-            ]
+                append type ";"
+                copy/part type find type ";")
+            ] else "text/plain"
 
             length: content-length: attempt [to integer! length] else [0]
 


### PR DESCRIPTION
error if no ";" found in the content-type
```
8-Feb-2020/15:29:11.454483+0:00 make error! [
    type: 'Script
    id: 'invalid-type
    message: [:arg1 "type is not allowed here"]
    near: [...
        copy/part type (opt find type ...) ~~]
    where: [all make transcribe case switch _ wake-up if while _ wait trap do catch either else _ do console]
    file: _
    line: 276
    arg1: #[datatype! void!]
]
```