### PR TITLE
Update httpd.reb

### DIFF
--- a/httpd.reb
+++ b/httpd.reb
@@ -78,7 +78,10 @@ sys/make-scheme [
                         dispatch client
                     ]
 
-                    default [if not empty? client/data [read client]]
+                    default [
+                        if not empty? client/data [
+                        if trap [read client][close client]
+                    ]]
                 ]
             ]
 


### PR DESCRIPTION
client closing the port doesn't show in `client/locals/parent/locals/open?`
so this traps a read on a closed port